### PR TITLE
adding heroku docker build config

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec puma -p $PORT

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    web: Dockerfile


### PR DESCRIPTION
Removing legacy Heroku Procfile, adding heroku.yml docker build config.

Once this works, Heroku will build the docker image, and hopefully, deploy it. No codeship needed just to build a image.