### PR TITLE
change this to use the first_name property of thing instead of `name`

### DIFF
--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -1,5 +1,5 @@
 %h4
   = t("titles.adopted", :thing_name => @thing.display_name != "" ? @thing.display_name.titleize : t("defaults.this_thing", :thing => t("defaults.thing")))
 %div
-  = t("titles.byline", :name => @thing.user.name)
+  = t("titles.byline", :name => @thing.user.first_name)
   = t("titles.ofline", :organization => @thing.user.organization) unless @thing.user.organization.blank?


### PR DESCRIPTION
Grabbed the `first_name` property out of the object

![Screen Shot 2019-06-18 at 8 06 54 PM](https://user-images.githubusercontent.com/51731/59727694-ad81cc00-9204-11e9-8111-fc49bbe61e2f.png)
